### PR TITLE
Refactor: events and reactions

### DIFF
--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -57,23 +57,19 @@ public protocol CommandHandler {
 
 public extension CommandHandler {
 
-  var progress: Event<CommandType> {
-    return Event.Progress
-  }
-
   func wait() {
-    publish(progress)
+    publish(event: Event.Progress)
   }
 
-  func fulfill(output: CommandType.Output) {
-    publish(Event.Success(output))
+  func publish(data output: CommandType.Output) {
+    publish(event: Event.Data(output))
   }
 
-  func reject(error: ErrorType) {
-    publish(Event.Error(error))
+  func publish(error error: ErrorType) {
+    publish(event: Event.Error(error))
   }
 
-  func publish(event: Event<CommandType>) {
+  func publish(event event: Event<CommandType>) {
     Engine.sharedInstance.eventBus.publish(event)
   }
 }

--- a/Sources/Aftermath/Event.swift
+++ b/Sources/Aftermath/Event.swift
@@ -12,7 +12,7 @@ public protocol AnyEvent: Identifiable, ErrorEventBuilder {
 
 public enum Event<T: Command>: AnyEvent {
   case Progress
-  case Success(T.Output)
+  case Data(T.Output)
   case Error(ErrorType)
 
   // MARK: - Helpers
@@ -34,7 +34,7 @@ public enum Event<T: Command>: AnyEvent {
     var value: Any?
 
     switch self {
-    case .Success(let result):
+    case .Data(let result):
       value = result
     default:
       break

--- a/Sources/Aftermath/Helpers.swift
+++ b/Sources/Aftermath/Helpers.swift
@@ -16,18 +16,18 @@ public extension Identifiable {
 
 struct Middleware<T> {
 
-  typealias Publish = (T) throws -> Void
-  typealias PublishCombination = (Publish) throws -> Publish
+  typealias Dispatch = (T) throws -> Void
+  typealias DispatchCombination = (Dispatch) throws -> Dispatch
 
-  let intercept: (T, execute: Publish, next: Publish) throws -> Void
+  let intercept: (T, dispatch: Dispatch, next: Dispatch) throws -> Void
 
-  func compose(execute: Publish) throws -> PublishCombination {
+  func compose(execute: Dispatch) throws -> DispatchCombination {
     return try respond { next, command in
-      return try self.intercept(command, execute: execute, next: next)
+      return try self.intercept(command, dispatch: execute, next: next)
     }
   }
 
-  func respond(handle: (Publish, T) throws -> Void) throws -> PublishCombination {
+  func respond(handle: (Dispatch, T) throws -> Void) throws -> DispatchCombination {
     return { next in
       return { command in
         try handle(next, command)

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -3,8 +3,8 @@
 public struct Reaction<T> {
 
   public typealias Progress = () -> Void
-  public typealias Done = (T) -> Void
-  public typealias Fail = (ErrorType) -> Void
+  public typealias Done = T -> Void
+  public typealias Fail = ErrorType -> Void
 
   public var progress: Progress?
   public var done: Done?

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -5,18 +5,15 @@ public struct Reaction<T> {
   public typealias Progress = () -> Void
   public typealias Done = (T) -> Void
   public typealias Fail = (ErrorType) -> Void
-  public typealias Complete = () -> Void
 
   public var progress: Progress?
   public var done: Done?
   public var fail: Fail?
-  public var complete: Complete?
 
-  public init(progress: Progress? = nil, done: Done? = nil, fail: Fail? = nil, complete: Complete? = nil) {
+  public init(progress: Progress? = nil, done: Done? = nil, fail: Fail? = nil) {
     self.progress = progress
     self.done = done
     self.fail = fail
-    self.complete = complete
   }
 
   func invoke<U: Command where U.Output == T>(with event: Event<U>) {
@@ -25,10 +22,8 @@ public struct Reaction<T> {
       progress?()
     case .Success(let result):
       done?(result)
-      complete?()
     case .Error(let error):
       fail?(error)
-      complete?()
     }
   }
 }

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -1,29 +1,29 @@
 // MARK: - Reaction
 
-public struct Reaction<T> {
+public final class Reaction<T> {
 
-  public typealias Progress = () -> Void
-  public typealias Done = T -> Void
-  public typealias Fail = ErrorType -> Void
+  public typealias Wait = () -> Void
+  public typealias Consume = T -> Void
+  public typealias Rescue = ErrorType -> Void
 
-  public var progress: Progress?
-  public var done: Done?
-  public var fail: Fail?
+  public var wait: Wait?
+  public var consume: Consume?
+  public var rescue: Rescue?
 
-  public init(progress: Progress? = nil, done: Done? = nil, fail: Fail? = nil) {
-    self.progress = progress
-    self.done = done
-    self.fail = fail
+  public init(wait: Wait? = nil, consume: Consume? = nil, rescue: Rescue? = nil) {
+    self.wait = wait
+    self.consume = consume
+    self.rescue = rescue
   }
 
   func invoke<U: Command where U.Output == T>(with event: Event<U>) {
     switch event {
     case .Progress:
-      progress?()
-    case .Data(let result):
-      done?(result)
+      wait?()
+    case .Data(let output):
+      consume?(output)
     case .Error(let error):
-      fail?(error)
+      rescue?(error)
     }
   }
 }

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -20,7 +20,7 @@ public struct Reaction<T> {
     switch event {
     case .Progress:
       progress?()
-    case .Success(let result):
+    case .Data(let result):
       done?(result)
     case .Error(let error):
       fail?(error)

--- a/Tests/Aftermath/CommandBusTests.swift
+++ b/Tests/Aftermath/CommandBusTests.swift
@@ -159,7 +159,7 @@ class CommandBusTests: XCTestCase {
     var reactionError: ErrorType?
 
     eventBus.listen(to: TestCommand.self) { event in
-      let reaction = Reaction<String>(fail: { error in
+      let reaction = Reaction<String>(rescue: { error in
         reactionError = error
       })
 
@@ -174,7 +174,7 @@ class CommandBusTests: XCTestCase {
     var reactionError: ErrorType?
 
     eventBus.listen(to: TestCommand.self) { event in
-      let reaction = Reaction<String>(fail: { error in
+      let reaction = Reaction<String>(rescue: { error in
         reactionError = error
       })
 

--- a/Tests/Aftermath/CommandHandlerTests.swift
+++ b/Tests/Aftermath/CommandHandlerTests.swift
@@ -25,7 +25,7 @@ class CommandHandlerTests: XCTestCase {
     var executed = false
 
     controller.react(to: TestCommand.self, with:
-      Reaction(progress: { executed = true }))
+      Reaction(wait: { executed = true }))
 
     XCTAssertFalse(executed)
     commandHandler.wait()
@@ -37,7 +37,7 @@ class CommandHandlerTests: XCTestCase {
     let output = "Data"
 
     controller.react(to: TestCommand.self, with:
-      Reaction(done: { output in result = output }))
+      Reaction(consume: { output in result = output }))
 
     XCTAssertNil(result)
     commandHandler.publish(data: output)
@@ -48,7 +48,7 @@ class CommandHandlerTests: XCTestCase {
     var resultError: ErrorType?
 
     controller.react(to: TestCommand.self, with:
-      Reaction(fail: { error in resultError = error }))
+      Reaction(rescue: { error in resultError = error }))
 
     XCTAssertNil(resultError)
     commandHandler.publish(error: TestError.Test)
@@ -59,7 +59,7 @@ class CommandHandlerTests: XCTestCase {
     var executed = false
 
     controller.react(to: TestCommand.self, with:
-      Reaction(progress: { executed = true }))
+      Reaction(wait: { executed = true } ))
 
     XCTAssertFalse(executed)
     commandHandler.publish(event: Event.Progress)

--- a/Tests/Aftermath/CommandHandlerTests.swift
+++ b/Tests/Aftermath/CommandHandlerTests.swift
@@ -21,10 +21,6 @@ class CommandHandlerTests: XCTestCase {
 
   // MARK: - Tests
 
-  func testProgress() {
-    XCTAssertTrue(commandHandler.progress.inProgress)
-  }
-
   func testWait() {
     var executed = false
 
@@ -36,7 +32,7 @@ class CommandHandlerTests: XCTestCase {
     XCTAssertTrue(executed)
   }
 
-  func testFulfill() {
+  func testPublishData() {
     var result: String?
     let output = "Data"
 
@@ -44,7 +40,7 @@ class CommandHandlerTests: XCTestCase {
       Reaction(done: { output in result = output }))
 
     XCTAssertNil(result)
-    commandHandler.fulfill(output)
+    commandHandler.publish(data: output)
     XCTAssertEqual(result, output)
   }
 
@@ -55,7 +51,7 @@ class CommandHandlerTests: XCTestCase {
       Reaction(fail: { error in resultError = error }))
 
     XCTAssertNil(resultError)
-    commandHandler.reject(TestError.Test)
+    commandHandler.publish(error: TestError.Test)
     XCTAssertTrue(resultError is TestError)
   }
 
@@ -66,7 +62,7 @@ class CommandHandlerTests: XCTestCase {
       Reaction(progress: { executed = true }))
 
     XCTAssertFalse(executed)
-    commandHandler.publish(Event.Progress)
+    commandHandler.publish(event: Event.Progress)
     XCTAssertTrue(executed)
   }
 }

--- a/Tests/Aftermath/CommandHandlerTests.swift
+++ b/Tests/Aftermath/CommandHandlerTests.swift
@@ -38,7 +38,7 @@ class CommandHandlerTests: XCTestCase {
 
   func testFulfill() {
     var result: String?
-    let output = "Success"
+    let output = "Data"
 
     controller.react(to: TestCommand.self, with:
       Reaction(done: { output in result = output }))

--- a/Tests/Aftermath/CommandMiddlewareTests.swift
+++ b/Tests/Aftermath/CommandMiddlewareTests.swift
@@ -18,7 +18,7 @@ class CommandMiddlewareTests: XCTestCase, CommandStepAsserting {
     eventBus = EventBus()
     commandBus = CommandBus(eventDispatcher: eventBus)
 
-    reaction = Reaction(done: { calculator in
+    reaction = Reaction(consume: { calculator in
       self.result = calculator.result
     })
 

--- a/Tests/Aftermath/CommandProducerTests.swift
+++ b/Tests/Aftermath/CommandProducerTests.swift
@@ -41,7 +41,7 @@ class CommandProducerTests: XCTestCase {
     var string: String?
 
     producer.execute(TestCommand(), reaction: Reaction(
-      done: { result in
+      consume: { result in
         string = result
       }))
 

--- a/Tests/Aftermath/EventBusTests.swift
+++ b/Tests/Aftermath/EventBusTests.swift
@@ -22,7 +22,7 @@ class EventBusTests: XCTestCase {
         self.state = .Progress
       },
       done: { result in
-        self.state = .Success
+        self.state = .Data
       },
       fail: { error in
         self.state = .Error

--- a/Tests/Aftermath/EventBusTests.swift
+++ b/Tests/Aftermath/EventBusTests.swift
@@ -18,16 +18,17 @@ class EventBusTests: XCTestCase {
     eventBus.errorHandler = errorHandler
 
     reaction = Reaction(
-      progress: {
+      wait: {
         self.state = .Progress
       },
-      done: { result in
+      consume: { result in
         self.state = .Data
       },
-      fail: { error in
+      rescue: { error in
         self.state = .Error
         self.lastError = error
-    })
+      }
+    )
 
     listener = { event in
       self.reaction.invoke(with: event)

--- a/Tests/Aftermath/EventMiddlewareTests.swift
+++ b/Tests/Aftermath/EventMiddlewareTests.swift
@@ -45,7 +45,7 @@ class EventMiddlewareTests: XCTestCase, EventStepAsserting {
   func testNext() {
     var m1 = LogEventMiddleware()
     var m2 = LogEventMiddleware()
-    let event = Event<AdditionCommand>.Success(Calculator(result: 11))
+    let event = Event<AdditionCommand>.Data(Calculator(result: 11))
 
     m1.callback = addMiddlewareStep(m1)
     m2.callback = addMiddlewareStep(m2)
@@ -67,7 +67,7 @@ class EventMiddlewareTests: XCTestCase, EventStepAsserting {
     var m1 = LogEventMiddleware()
     var m2 = ErrorEventMiddleware()
     var m3 = LogEventMiddleware()
-    let successEvent = Event<AdditionCommand>.Success(Calculator(result: 11))
+    let dataEvent = Event<AdditionCommand>.Data(Calculator(result: 11))
     let errorEvent = Event<AdditionCommand>.Error(TestError.Test)
 
     m1.callback = addMiddlewareStep(m1)
@@ -76,14 +76,14 @@ class EventMiddlewareTests: XCTestCase, EventStepAsserting {
 
     eventBus.middlewares = [m1, m2, m3]
     eventBus.listen(to: AdditionCommand.self, listener: listener)
-    eventBus.publish(successEvent)
+    eventBus.publish(dataEvent)
 
     XCTAssertEqual(eventSteps.count, 6)
     XCTAssertEqual(result, 0)
     XCTAssertTrue(error is TestError)
 
-    assertMiddlewareStep(0, expected: (middleware: m1, event: successEvent))
-    assertMiddlewareStep(1, expected: (middleware: m2, event: successEvent))
+    assertMiddlewareStep(0, expected: (middleware: m1, event: dataEvent))
+    assertMiddlewareStep(1, expected: (middleware: m2, event: dataEvent))
     assertMiddlewareStep(2, expected: (middleware: m1, event: errorEvent))
     assertMiddlewareStep(3, expected: (middleware: m2, event: errorEvent))
     assertMiddlewareStep(4, expected: (middleware: m3, event: errorEvent))
@@ -94,7 +94,7 @@ class EventMiddlewareTests: XCTestCase, EventStepAsserting {
     var m1 = LogEventMiddleware()
     var m2 = AbortEventMiddleware()
     var m3 = LogEventMiddleware()
-    let event = Event<AdditionCommand>.Success(Calculator(result: 11))
+    let event = Event<AdditionCommand>.Data(Calculator(result: 11))
 
     m1.callback = addMiddlewareStep(m1)
     m2.callback = addMiddlewareStep(m2)

--- a/Tests/Aftermath/EventMiddlewareTests.swift
+++ b/Tests/Aftermath/EventMiddlewareTests.swift
@@ -17,10 +17,10 @@ class EventMiddlewareTests: XCTestCase, EventStepAsserting {
     eventBus = EventBus()
 
     reaction = Reaction(
-      done: { calculator in
+      consume: { calculator in
         self.result = calculator.result
       },
-      fail: { error in
+      rescue: { error in
         self.error = error
       }
     )

--- a/Tests/Aftermath/EventTests.swift
+++ b/Tests/Aftermath/EventTests.swift
@@ -14,8 +14,8 @@ class EventTests: XCTestCase {
     let progressEvent = Event<TestCommand>.Progress
     XCTAssertTrue(progressEvent.inProgress)
 
-    let successEvent = Event<TestCommand>.Success("Success")
-    XCTAssertFalse(successEvent.inProgress)
+    let dataEvent = Event<TestCommand>.Data("Data")
+    XCTAssertFalse(dataEvent.inProgress)
 
     let errorEvent = Event<TestCommand>.Error(TestError.Test)
     XCTAssertFalse(errorEvent.inProgress)
@@ -25,9 +25,9 @@ class EventTests: XCTestCase {
     let progressEvent = Event<TestCommand>.Progress
     XCTAssertNil(progressEvent.result)
 
-    let result = "Success"
-    let successEvent = Event<TestCommand>.Success(result)
-    XCTAssertEqual(successEvent.result as? String, result)
+    let result = "Data"
+    let dataEvent = Event<TestCommand>.Data(result)
+    XCTAssertEqual(dataEvent.result as? String, result)
 
     let errorEvent = Event<TestCommand>.Error(TestError.Test)
     XCTAssertNil(errorEvent.result)
@@ -37,8 +37,8 @@ class EventTests: XCTestCase {
     let progressEvent = Event<TestCommand>.Progress
     XCTAssertNil(progressEvent.error)
 
-    let successEvent = Event<TestCommand>.Success("Success")
-    XCTAssertNil(successEvent.error)
+    let dataEvent = Event<TestCommand>.Data("Data")
+    XCTAssertNil(dataEvent.error)
 
     let errorEvent = Event<TestCommand>.Error(TestError.Test)
     XCTAssertTrue(errorEvent.error is TestError)

--- a/Tests/Aftermath/Helpers/Commands.swift
+++ b/Tests/Aftermath/Helpers/Commands.swift
@@ -41,7 +41,7 @@ struct TestCommandHandler: CommandHandler {
 
   func handle(command: TestCommand) throws -> Event<TestCommand> {
     callback?(command)
-    return Event.Success(result)
+    return Event.Data(result)
   }
 }
 
@@ -55,7 +55,7 @@ struct AdditionCommandHandler: CommandHandler {
 
   func handle(command: AdditionCommand) throws -> Event<AdditionCommand> {
     callback?(command)
-    return Event.Success(Calculator(result: command.value1 + command.value2))
+    return Event.Data(Calculator(result: command.value1 + command.value2))
   }
 }
 
@@ -69,7 +69,7 @@ struct SubtractionCommandHandler: CommandHandler {
 
   func handle(command: SubtractionCommand) throws -> Event<SubtractionCommand> {
     callback?(command)
-    return Event.Success(Calculator(result: command.value1 - command.value2))
+    return Event.Data(Calculator(result: command.value1 - command.value2))
   }
 }
 

--- a/Tests/Aftermath/Helpers/Events.swift
+++ b/Tests/Aftermath/Helpers/Events.swift
@@ -34,7 +34,7 @@ struct ErrorEventMiddleware: EventMiddleware {
     }
 
     switch additionEvent {
-    case .Success:
+    case .Data:
       try publish(Event<AdditionCommand>.Error(TestError.Test))
     default:
       try next(event)

--- a/Tests/Aftermath/Helpers/Types.swift
+++ b/Tests/Aftermath/Helpers/Types.swift
@@ -7,7 +7,7 @@ struct Calculator {
 }
 
 enum State: Int {
-  case Progress, Success, Error
+  case Progress, Data, Error
 }
 
 enum TestError: ErrorType {
@@ -40,7 +40,7 @@ class Controller: CommandProducer, ReactionProducer {
         self.state = .Progress
       },
       done: { result in
-        self.state = .Success
+        self.state = .Data
       },
       fail: { error in
         self.state = .Error

--- a/Tests/Aftermath/Helpers/Types.swift
+++ b/Tests/Aftermath/Helpers/Types.swift
@@ -33,7 +33,6 @@ class Controller: CommandProducer, ReactionProducer {
 
   var reaction: Reaction<Calculator>!
   var state: State?
-  var completed = false
 
   init() {
     reaction = Reaction(
@@ -45,9 +44,6 @@ class Controller: CommandProducer, ReactionProducer {
       },
       fail: { error in
         self.state = .Error
-      },
-      complete: {
-        self.completed = true
       }
     )
   }

--- a/Tests/Aftermath/Helpers/Types.swift
+++ b/Tests/Aftermath/Helpers/Types.swift
@@ -36,13 +36,13 @@ class Controller: CommandProducer, ReactionProducer {
 
   init() {
     reaction = Reaction(
-      progress: {
+      wait: {
         self.state = .Progress
       },
-      done: { result in
+      consume: { result in
         self.state = .Data
       },
-      fail: { error in
+      rescue: { error in
         self.state = .Error
       }
     )

--- a/Tests/Aftermath/ReactionProducerTests.swift
+++ b/Tests/Aftermath/ReactionProducerTests.swift
@@ -28,15 +28,15 @@ class ReactionProducerTests: XCTestCase {
     XCTAssertEqual(controller.state, .Progress)
   }
 
-  func testReactWithSuccess() {
+  func testReactWithData() {
     controller.react(to: AdditionCommand.self, with: controller.reaction)
     XCTAssertEqual((Engine.sharedInstance.eventBus as? EventBus)?.listeners.count, 1)
     XCTAssertEqual(Engine.sharedInstance.reactionDisposer.tokens[Controller.identifier]?.count, 1)
 
-    let event = Event<AdditionCommand>.Success(Calculator(result: 11))
+    let event = Event<AdditionCommand>.Data(Calculator(result: 11))
     Engine.sharedInstance.eventBus.publish(event)
 
-    XCTAssertEqual(controller.state, .Success)
+    XCTAssertEqual(controller.state, .Data)
   }
 
   func testReactWithError() {

--- a/Tests/Aftermath/ReactionProducerTests.swift
+++ b/Tests/Aftermath/ReactionProducerTests.swift
@@ -26,7 +26,6 @@ class ReactionProducerTests: XCTestCase {
     Engine.sharedInstance.eventBus.publish(event)
 
     XCTAssertEqual(controller.state, .Progress)
-    XCTAssertFalse(controller.completed)
   }
 
   func testReactWithSuccess() {
@@ -38,7 +37,6 @@ class ReactionProducerTests: XCTestCase {
     Engine.sharedInstance.eventBus.publish(event)
 
     XCTAssertEqual(controller.state, .Success)
-    XCTAssertTrue(controller.completed)
   }
 
   func testReactWithError() {
@@ -50,7 +48,6 @@ class ReactionProducerTests: XCTestCase {
     Engine.sharedInstance.eventBus.publish(event)
 
     XCTAssertEqual(controller.state, .Error)
-    XCTAssertTrue(controller.completed)
   }
 
   func testDispose() {

--- a/Tests/Aftermath/ReactionTests.swift
+++ b/Tests/Aftermath/ReactionTests.swift
@@ -12,13 +12,13 @@ class ReactionTests: XCTestCase {
     state = nil
 
     reaction = Reaction(
-      progress: {
+      wait: {
         self.state = .Progress
       },
-      done: { result in
+      consume: { result in
         self.state = .Data
       },
-      fail: { error in
+      rescue: { error in
         self.state = .Error
       }
     )
@@ -33,15 +33,15 @@ class ReactionTests: XCTestCase {
   func testInitWithoutParameters() {
     reaction = Reaction()
 
-    XCTAssertNil(reaction.progress)
-    XCTAssertNil(reaction.done)
-    XCTAssertNil(reaction.fail)
+    XCTAssertNil(reaction.wait)
+    XCTAssertNil(reaction.consume)
+    XCTAssertNil(reaction.rescue)
   }
 
   func testInitWithParameters() {
-    XCTAssertNotNil(reaction.progress)
-    XCTAssertNotNil(reaction.done)
-    XCTAssertNotNil(reaction.fail)
+    XCTAssertNotNil(reaction.wait)
+    XCTAssertNotNil(reaction.consume)
+    XCTAssertNotNil(reaction.rescue)
   }
 
   func testInvokeWithProgress() {

--- a/Tests/Aftermath/ReactionTests.swift
+++ b/Tests/Aftermath/ReactionTests.swift
@@ -16,7 +16,7 @@ class ReactionTests: XCTestCase {
         self.state = .Progress
       },
       done: { result in
-        self.state = .Success
+        self.state = .Data
       },
       fail: { error in
         self.state = .Error
@@ -51,11 +51,11 @@ class ReactionTests: XCTestCase {
     XCTAssertEqual(state, .Progress)
   }
 
-  func testInvokeWithSuccess() {
-    let event = Event<AdditionCommand>.Success(Calculator(result: 11))
+  func testInvokeWithData() {
+    let event = Event<AdditionCommand>.Data(Calculator(result: 11))
     reaction.invoke(with: event)
 
-    XCTAssertEqual(state, .Success)
+    XCTAssertEqual(state, .Data)
   }
 
   func testInvokeWithError() {

--- a/Tests/Aftermath/ReactionTests.swift
+++ b/Tests/Aftermath/ReactionTests.swift
@@ -5,13 +5,11 @@ class ReactionTests: XCTestCase {
 
   var reaction: Reaction<Calculator>!
   var state: State?
-  var completed = false
 
   override func setUp() {
     super.setUp()
 
     state = nil
-    completed = false
 
     reaction = Reaction(
       progress: {
@@ -22,9 +20,6 @@ class ReactionTests: XCTestCase {
       },
       fail: { error in
         self.state = .Error
-      },
-      complete: {
-        self.completed = true
       }
     )
   }
@@ -41,14 +36,12 @@ class ReactionTests: XCTestCase {
     XCTAssertNil(reaction.progress)
     XCTAssertNil(reaction.done)
     XCTAssertNil(reaction.fail)
-    XCTAssertNil(reaction.complete)
   }
 
   func testInitWithParameters() {
     XCTAssertNotNil(reaction.progress)
     XCTAssertNotNil(reaction.done)
     XCTAssertNotNil(reaction.fail)
-    XCTAssertNotNil(reaction.complete)
   }
 
   func testInvokeWithProgress() {
@@ -56,7 +49,6 @@ class ReactionTests: XCTestCase {
     reaction.invoke(with: event)
 
     XCTAssertEqual(state, .Progress)
-    XCTAssertFalse(completed)
   }
 
   func testInvokeWithSuccess() {
@@ -64,7 +56,6 @@ class ReactionTests: XCTestCase {
     reaction.invoke(with: event)
 
     XCTAssertEqual(state, .Success)
-    XCTAssertTrue(completed)
   }
 
   func testInvokeWithError() {
@@ -72,6 +63,5 @@ class ReactionTests: XCTestCase {
     reaction.invoke(with: event)
 
     XCTAssertEqual(state, .Error)
-    XCTAssertTrue(completed)
   }
 }


### PR DESCRIPTION
- Remove completion closure because `Reaction` is a listener and never completes.
- Rename `Event.Success` to `Event.Data`
- Rename reaction callbacks:

```
process -> wait
done -> consume
fail -> rescue 
```
