### PR TITLE
Feature: actions and facts

### DIFF
--- a/Aftermath.xcodeproj/project.pbxproj
+++ b/Aftermath.xcodeproj/project.pbxproj
@@ -67,6 +67,10 @@
 		D57462F21D6BAE3300E0C876 /* CommandMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57462F01D6BAE3300E0C876 /* CommandMiddlewareTests.swift */; };
 		D57462F41D6BB63300E0C876 /* EventMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57462F31D6BB63300E0C876 /* EventMiddlewareTests.swift */; };
 		D57462F51D6BB63300E0C876 /* EventMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57462F31D6BB63300E0C876 /* EventMiddlewareTests.swift */; };
+		D57A57531D85F9B200F78661 /* FactProducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57A57521D85F9B200F78661 /* FactProducerTests.swift */; };
+		D57A57541D85F9B200F78661 /* FactProducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57A57521D85F9B200F78661 /* FactProducerTests.swift */; };
+		D57A57561D85FAC500F78661 /* Fact.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57A57551D85FAC500F78661 /* Fact.swift */; };
+		D57A57571D85FAC500F78661 /* Fact.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57A57551D85FAC500F78661 /* Fact.swift */; };
 		D59CC11A1D76141400D72C39 /* ReactionDisposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1191D76141400D72C39 /* ReactionDisposer.swift */; };
 		D59CC11B1D76142400D72C39 /* ReactionDisposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC1191D76141400D72C39 /* ReactionDisposer.swift */; };
 		D59CC11D1D76145600D72C39 /* ReactionDisposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59CC11C1D76145600D72C39 /* ReactionDisposerTests.swift */; };
@@ -129,6 +133,8 @@
 		D579C4621D6B9CEB00EDD4A8 /* IdentifiableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifiableTests.swift; sourceTree = "<group>"; };
 		D579C4631D6B9CEB00EDD4A8 /* ReactionProducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionProducerTests.swift; sourceTree = "<group>"; };
 		D579C4641D6B9CEB00EDD4A8 /* ReactionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionTests.swift; sourceTree = "<group>"; };
+		D57A57521D85F9B200F78661 /* FactProducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FactProducerTests.swift; sourceTree = "<group>"; };
+		D57A57551D85FAC500F78661 /* Fact.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fact.swift; sourceTree = "<group>"; };
 		D59CC1191D76141400D72C39 /* ReactionDisposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionDisposer.swift; sourceTree = "<group>"; };
 		D59CC11C1D76145600D72C39 /* ReactionDisposerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionDisposerTests.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Aftermath.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Aftermath.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -192,6 +198,7 @@
 				D574629D1D6BA37D00E0C876 /* Error.swift */,
 				D574629E1D6BA37D00E0C876 /* Event.swift */,
 				D574629F1D6BA37D00E0C876 /* EventBus.swift */,
+				D57A57551D85FAC500F78661 /* Fact.swift */,
 				D57462A01D6BA37D00E0C876 /* Helpers.swift */,
 				D57462A11D6BA37D00E0C876 /* Listener.swift */,
 				D57462A21D6BA37D00E0C876 /* Reaction.swift */,
@@ -216,6 +223,7 @@
 				D579C45C1D6B9CEB00EDD4A8 /* ErrorTests.swift */,
 				D57462F31D6BB63300E0C876 /* EventMiddlewareTests.swift */,
 				D579C45D1D6B9CEB00EDD4A8 /* EventTests.swift */,
+				D57A57521D85F9B200F78661 /* FactProducerTests.swift */,
 				D579C4621D6B9CEB00EDD4A8 /* IdentifiableTests.swift */,
 				D579C4631D6B9CEB00EDD4A8 /* ReactionProducerTests.swift */,
 				D579C4641D6B9CEB00EDD4A8 /* ReactionTests.swift */,
@@ -456,6 +464,7 @@
 				D57462AA1D6BA37D00E0C876 /* Helpers.swift in Sources */,
 				D57462A71D6BA37D00E0C876 /* Error.swift in Sources */,
 				D57462AC1D6BA37D00E0C876 /* Reaction.swift in Sources */,
+				D57A57561D85FAC500F78661 /* Fact.swift in Sources */,
 				D57462A81D6BA37D00E0C876 /* Event.swift in Sources */,
 				D57462A91D6BA37D00E0C876 /* EventBus.swift in Sources */,
 				D57462A31D6BA37D00E0C876 /* Command.swift in Sources */,
@@ -484,6 +493,7 @@
 				D57462D01D6BA3BD00E0C876 /* CommandHandlerTests.swift in Sources */,
 				D57462701D6BA0A300E0C876 /* Types.swift in Sources */,
 				D57462D41D6BA3BD00E0C876 /* ErrorTests.swift in Sources */,
+				D57A57531D85F9B200F78661 /* FactProducerTests.swift in Sources */,
 				D57462F41D6BB63300E0C876 /* EventMiddlewareTests.swift in Sources */,
 				D57462CD1D6BA3BD00E0C876 /* ListenerTests.swift in Sources */,
 				D57462CF1D6BA3BD00E0C876 /* CommandBusTests.swift in Sources */,
@@ -502,6 +512,7 @@
 				D57462B41D6BA38600E0C876 /* Helpers.swift in Sources */,
 				D57462B11D6BA38600E0C876 /* Error.swift in Sources */,
 				D57462B61D6BA38600E0C876 /* Reaction.swift in Sources */,
+				D57A57571D85FAC500F78661 /* Fact.swift in Sources */,
 				D57462B21D6BA38600E0C876 /* Event.swift in Sources */,
 				D57462B31D6BA38600E0C876 /* EventBus.swift in Sources */,
 				D57462AD1D6BA38600E0C876 /* Command.swift in Sources */,
@@ -530,6 +541,7 @@
 				D57462E11D6BA3BF00E0C876 /* CommandHandlerTests.swift in Sources */,
 				D57462731D6BA0A400E0C876 /* Types.swift in Sources */,
 				D57462E51D6BA3BF00E0C876 /* ErrorTests.swift in Sources */,
+				D57A57541D85F9B200F78661 /* FactProducerTests.swift in Sources */,
 				D57462F51D6BB63300E0C876 /* EventMiddlewareTests.swift in Sources */,
 				D57462DE1D6BA3BF00E0C876 /* ListenerTests.swift in Sources */,
 				D57462E01D6BA3BF00E0C876 /* CommandBusTests.swift in Sources */,

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -102,7 +102,11 @@ public protocol Fact: Action {
 public extension Fact {
 
   func handle(command: CommandType) throws -> Event<CommandType> {
-    return Event.Data(self as! CommandType.Output)
+    guard let output = self as? CommandType.Output else {
+      throw Error.InvalidFactType
+    }
+
+    return Event.Data(output)
   }
 }
 

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -74,6 +74,12 @@ public extension CommandHandler {
   }
 }
 
+// MARK: - Action
+
+public protocol Action: Command, CommandHandler {
+  associatedtype CommandType = Self
+}
+
 // MARK: - Command middleware
 
 public typealias Execute = (AnyCommand) throws -> Void

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -45,6 +45,10 @@ public extension CommandProducer {
 
     execute(command: action)
   }
+
+  func publish<T: Fact>(fact fact: T) {
+    execute(action: fact)
+  }
 }
 
 public extension CommandProducer where Self: ReactionProducer {
@@ -86,6 +90,20 @@ public extension CommandHandler {
 
 public protocol Action: Command, CommandHandler {
   associatedtype CommandType = Self
+}
+
+// MARK: - Fact
+
+public protocol Fact: Action {
+  associatedtype CommandType = Self
+  associatedtype Output = Self
+}
+
+public extension Fact {
+
+  func handle(command: CommandType) throws -> Event<CommandType> {
+    return Event.Data(self as! CommandType.Output)
+  }
 }
 
 // MARK: - Command middleware

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -45,10 +45,6 @@ public extension CommandProducer {
 
     execute(command: action)
   }
-
-  func publish<T: Fact>(fact fact: T) {
-    execute(action: fact)
-  }
 }
 
 public extension CommandProducer where Self: ReactionProducer {
@@ -90,24 +86,6 @@ public extension CommandHandler {
 
 public protocol Action: Command, CommandHandler {
   associatedtype CommandType = Self
-}
-
-// MARK: - Fact
-
-public protocol Fact: Action {
-  associatedtype CommandType = Self
-  associatedtype Output = Self
-}
-
-public extension Fact {
-
-  func handle(command: CommandType) throws -> Event<CommandType> {
-    guard let output = self as? CommandType.Output else {
-      throw Error.InvalidFactType
-    }
-
-    return Event.Data(output)
-  }
 }
 
 // MARK: - Command middleware

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -37,6 +37,14 @@ public extension CommandProducer {
   func execute(builder: CommandBuilder) {
     Engine.sharedInstance.commandBus.execute(builder)
   }
+
+  func execute<T: Action>(action: T) {
+    if !Engine.sharedInstance.commandBus.contains(T.self) {
+      Engine.sharedInstance.commandBus.use(action)
+    }
+
+    execute(action)
+  }
 }
 
 public extension CommandProducer where Self: ReactionProducer {

--- a/Sources/Aftermath/Command.swift
+++ b/Sources/Aftermath/Command.swift
@@ -30,20 +30,20 @@ public protocol CommandProducer {}
 
 public extension CommandProducer {
 
-  func execute(command: AnyCommand) {
+  func execute(command command: AnyCommand) {
     Engine.sharedInstance.commandBus.execute(command)
   }
 
-  func execute(builder: CommandBuilder) {
+  func execute(builder builder: CommandBuilder) {
     Engine.sharedInstance.commandBus.execute(builder)
   }
 
-  func execute<T: Action>(action: T) {
+  func execute<T: Action>(action action: T) {
     if !Engine.sharedInstance.commandBus.contains(T.self) {
       Engine.sharedInstance.commandBus.use(action)
     }
 
-    execute(action)
+    execute(command: action)
   }
 }
 
@@ -51,7 +51,7 @@ public extension CommandProducer where Self: ReactionProducer {
 
   func execute<T: Command>(command: T, reaction: Reaction<T.Output>) {
     react(to: T.self, with: reaction)
-    execute(command)
+    execute(command: command)
   }
 }
 

--- a/Sources/Aftermath/CommandBus.swift
+++ b/Sources/Aftermath/CommandBus.swift
@@ -10,6 +10,7 @@ public protocol CommandDispatcher: Disposer {
 
   init(eventDispatcher: EventDispatcher)
   func use<T: CommandHandler>(handler: T) -> DisposalToken
+  func contains<T: CommandHandler>(handler: T.Type) -> Bool
   func execute(command: AnyCommand)
   func execute(builder: CommandBuilder)
 }
@@ -41,7 +42,7 @@ final class CommandBus: CommandDispatcher, MutexDisposer {
 
     let token = T.CommandType.identifier
 
-    if listeners[token] != nil {
+    if contains(T.self) {
       let warning = Warning.DuplicatedCommandHandler(command: T.CommandType.self)
       errorHandler?.handleError(warning)
     }
@@ -62,6 +63,11 @@ final class CommandBus: CommandDispatcher, MutexDisposer {
     pthread_mutex_unlock(&mutex)
 
     return token
+  }
+
+  func contains<T: CommandHandler>(handler: T.Type) -> Bool {
+    let token = T.CommandType.identifier
+    return listeners[token] != nil
   }
 
   // MARK: - Dispatch

--- a/Sources/Aftermath/Error.swift
+++ b/Sources/Aftermath/Error.swift
@@ -6,6 +6,7 @@ public enum Error: ErrorType, CustomStringConvertible, CustomDebugStringConverti
   case CommandDispatcherDeallocated
   case EventDispatcherDeallocated
   case InvalidCommandType
+  case InvalidFactType
   case InvalidEventType
 
   public var description: String {
@@ -18,6 +19,8 @@ public enum Error: ErrorType, CustomStringConvertible, CustomDebugStringConverti
       string = "Event dispatcher has been deallocated."
     case .InvalidCommandType:
       string = "Invalid command type."
+    case .InvalidFactType:
+      string = "Invalid fact type."
     case .InvalidEventType:
       string = "Invalid event type."
     }

--- a/Sources/Aftermath/Fact.swift
+++ b/Sources/Aftermath/Fact.swift
@@ -12,7 +12,7 @@ public protocol FactProducer {}
 
 public extension FactProducer {
 
-  func publish<T: Fact>(fact fact: T) {
+  func post<T: Fact>(fact fact: T) {
     let event = Event<FactCommand<T>>.Data(fact)
     Engine.sharedInstance.eventBus.publish(event)
   }

--- a/Sources/Aftermath/Fact.swift
+++ b/Sources/Aftermath/Fact.swift
@@ -1,0 +1,19 @@
+public protocol Fact {}
+
+// MARK: - Fact command
+
+struct FactCommand<T: Fact>: Command {
+  typealias Output = T
+}
+
+// MARK: - Fact producer
+
+public protocol FactProducer {}
+
+public extension FactProducer {
+
+  func publish<T: Fact>(fact fact: T) {
+    let event = Event<FactCommand<T>>.Data(fact)
+    Engine.sharedInstance.eventBus.publish(event)
+  }
+}

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -52,6 +52,11 @@ public extension ReactionProducer {
     return token
   }
 
+  func next<T: Fact where T.Output == T>(consume: T -> Void) -> DisposalToken {
+    let reaction = Reaction<T>(consume: consume)
+    return react(to: T.self, with: reaction)
+  }
+
   func dispose(token: DisposalToken) {
     Engine.sharedInstance.reactionDisposer.dispose(token, from: self)
   }

--- a/Sources/Aftermath/Reaction.swift
+++ b/Sources/Aftermath/Reaction.swift
@@ -52,9 +52,9 @@ public extension ReactionProducer {
     return token
   }
 
-  func next<T: Fact where T.Output == T>(consume: T -> Void) -> DisposalToken {
+  func next<T: Fact>(consume: T -> Void) -> DisposalToken {
     let reaction = Reaction<T>(consume: consume)
-    return react(to: T.self, with: reaction)
+    return react(to: FactCommand<T>.self, with: reaction)
   }
 
   func dispose(token: DisposalToken) {

--- a/Tests/Aftermath/CommandBusTests.swift
+++ b/Tests/Aftermath/CommandBusTests.swift
@@ -62,6 +62,14 @@ class CommandBusTests: XCTestCase {
     }
   }
 
+  func testContains() {
+    XCTAssertEqual(commandBus.listeners.count, 0)
+    XCTAssertFalse(commandBus.contains(TestCommandHandler.self))
+
+    commandBus.use(commandHandler)
+    XCTAssertTrue(commandBus.contains(TestCommandHandler.self))
+  }
+
   func testExecute() {
     let token = commandBus.use(commandHandler)
     XCTAssertEqual(commandBus.listeners[token]?.status, .Pending)

--- a/Tests/Aftermath/CommandProducerTests.swift
+++ b/Tests/Aftermath/CommandProducerTests.swift
@@ -51,6 +51,22 @@ class CommandProducerTests: XCTestCase {
     XCTAssertNotNil(executedAction)
   }
 
+  func testPublishFact() {
+    var output: String?
+    let fact = TestFact(result: result)
+    let reactionProducer = TestReactionProducer()
+
+    reactionProducer.next { (fact: TestFact) in
+      output = fact.result
+    }
+
+    XCTAssertFalse(Engine.sharedInstance.commandBus.contains(TestFact.self))
+
+    producer.publish(fact: fact)
+    XCTAssertTrue(Engine.sharedInstance.commandBus.contains(TestFact.self))
+    XCTAssertEqual(output, result)
+  }
+
   func testExecuteReaction() {
     var string: String?
 

--- a/Tests/Aftermath/CommandProducerTests.swift
+++ b/Tests/Aftermath/CommandProducerTests.swift
@@ -37,7 +37,7 @@ class CommandProducerTests: XCTestCase {
     XCTAssertNil(executedCommand)
   }
 
-  func testDispatch() {
+  func testExecuteAction() {
     var executedAction: TestAction?
 
     let action = TestAction(result: result) { action in

--- a/Tests/Aftermath/CommandProducerTests.swift
+++ b/Tests/Aftermath/CommandProducerTests.swift
@@ -51,22 +51,6 @@ class CommandProducerTests: XCTestCase {
     XCTAssertNotNil(executedAction)
   }
 
-  func testPublishFact() {
-    var output: String?
-    let fact = TestFact(result: result)
-    let reactionProducer = TestReactionProducer()
-
-    reactionProducer.next { (fact: TestFact) in
-      output = fact.result
-    }
-
-    XCTAssertFalse(Engine.sharedInstance.commandBus.contains(TestFact.self))
-
-    producer.publish(fact: fact)
-    XCTAssertTrue(Engine.sharedInstance.commandBus.contains(TestFact.self))
-    XCTAssertEqual(output, result)
-  }
-
   func testExecuteReaction() {
     var string: String?
 

--- a/Tests/Aftermath/CommandProducerTests.swift
+++ b/Tests/Aftermath/CommandProducerTests.swift
@@ -28,13 +28,27 @@ class CommandProducerTests: XCTestCase {
   // MARK: - Tests
 
   func testExecute() {
-    producer.execute(TestCommand())
+    producer.execute(command: TestCommand())
     XCTAssertNotNil(executedCommand)
   }
 
   func testExecuteWithAnotherCommand() {
-    producer.execute(AdditionCommand(value1: 1, value2: 3))
+    producer.execute(command: AdditionCommand(value1: 1, value2: 3))
     XCTAssertNil(executedCommand)
+  }
+
+  func testDispatch() {
+    var executedAction: TestAction?
+
+    let action = TestAction(result: result) { action in
+      executedAction = action
+    }
+
+    XCTAssertFalse(Engine.sharedInstance.commandBus.contains(TestAction.self))
+
+    producer.execute(action: action)
+    XCTAssertTrue(Engine.sharedInstance.commandBus.contains(TestAction.self))
+    XCTAssertNotNil(executedAction)
   }
 
   func testExecuteReaction() {

--- a/Tests/Aftermath/FactProducerTests.swift
+++ b/Tests/Aftermath/FactProducerTests.swift
@@ -19,7 +19,7 @@ class FactProducerTests: XCTestCase {
 
   // MARK: - Tests
 
-  func testPublishFact() {
+  func testPost() {
     var output1: String?
     var output2: String?
     let reactionProducer1 = TestReactionProducer()
@@ -35,7 +35,7 @@ class FactProducerTests: XCTestCase {
 
     let fact = TestFact(result: result)
 
-    producer.publish(fact: fact)
+    producer.post(fact: fact)
     XCTAssertEqual(output1, result)
     XCTAssertEqual(output2, result)
   }

--- a/Tests/Aftermath/FactProducerTests.swift
+++ b/Tests/Aftermath/FactProducerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Aftermath
+
+class FactProducerTests: XCTestCase {
+
+  var producer: Controller!
+  let result = "test"
+
+  override func setUp() {
+    super.setUp()
+
+    producer = Controller()
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    Engine.sharedInstance.invalidate()
+  }
+
+  // MARK: - Tests
+
+  func testPublishFact() {
+    var output1: String?
+    var output2: String?
+    let reactionProducer1 = TestReactionProducer()
+    let reactionProducer2 = TestReactionProducer()
+
+    reactionProducer1.next { (fact: TestFact) in
+      output1 = fact.result
+    }
+
+    reactionProducer2.next { (fact: TestFact) in
+      output2 = fact.result
+    }
+
+    let fact = TestFact(result: result)
+
+    producer.publish(fact: fact)
+    XCTAssertEqual(output1, result)
+    XCTAssertEqual(output2, result)
+  }
+}

--- a/Tests/Aftermath/Helpers/Commands.swift
+++ b/Tests/Aftermath/Helpers/Commands.swift
@@ -27,6 +27,23 @@ struct TestCommandBuilder: CommandBuilder {
   }
 }
 
+struct TestAction: Action {
+  typealias Output = String
+
+  let result: String
+  var callback: (TestAction -> Void)?
+
+  init(result: String = "", callback: (TestAction -> Void)? = nil) {
+    self.result = result
+    self.callback = callback
+  }
+
+  func handle(command: TestAction) throws -> Event<TestAction> {
+    callback?(command)
+    return Event.Data(result)
+  }
+}
+
 // MARK: - Command handlers
 
 struct TestCommandHandler: CommandHandler {

--- a/Tests/Aftermath/Helpers/Commands.swift
+++ b/Tests/Aftermath/Helpers/Commands.swift
@@ -44,6 +44,10 @@ struct TestAction: Action {
   }
 }
 
+struct TestFact: Fact {
+  let result: String
+}
+
 // MARK: - Command handlers
 
 struct TestCommandHandler: CommandHandler {

--- a/Tests/Aftermath/Helpers/Types.swift
+++ b/Tests/Aftermath/Helpers/Types.swift
@@ -29,7 +29,7 @@ class ErrorManager: ErrorHandler {
 
 // MARK: - Reactions
 
-class Controller: CommandProducer, ReactionProducer {
+class Controller: CommandProducer, ReactionProducer, FactProducer {
 
   var reaction: Reaction<Calculator>!
   var state: State?


### PR DESCRIPTION
@zenangst @RamonGilabert @onmyway133 
Here we introduce 2 new helper types that could make life easier in some specific cases:

**Action**
`Action` is a command that handles itself. Sounds weird, but it's actually what it is if you look at protocol declaration:

``` swift
public protocol Action: Command, CommandHandler {
  associatedtype CommandType = Self
}
```

The idea is to have both command object and command handler in one place. I wouldn't do it very often, but sometimes it probably makes sense for better understanding the flow or when command itself or business logic are super tiny, so you feel like it's overhead to create 2 new types.

``` swift
import Sugar

struct WelcomeAction: Action {
  typealias Output = String

  let name: String

  init(name: String) {
    self.name = name
  }

  func handle(command: WelcomeAction) throws -> Event<WelcomeAction> {
    delay(1.0) {
      self.publish(data: "Hello \(name)")
    }
    return Event.Progress
  }
}

// ...
execute(WelcomeAction(name: "World"))
```

The good thing about actions is that there is no need to register your command handler, it will be done automatically when you execute:

``` swift
execute(action: action)
```

**Fact**
On the other hand, fact works like notification with no async operations involved. It could be used when there is no need to have a handler and generate an output, fact is already an output and the only thing you want to do is notify all subscribers that something happened in the system and they will react accordingly. In this sense it's closer to a type-safe alternative to `NSNotification`.

``` swift
struct LoginFact: Fact {
  let username: String
}

class ProfileController: UIViewController, ReactionProducer {

  override func viewDidLoad() {
    super.viewDidLoad()

    reactionProducer.next { (fact: LoginFact) in
      title = fact.username
    }
  }
}

struct AuthService: FactProducer {
  func login() {
    let fact = LoginFact(username: "John Doe")
    post(fact: fact)  
  }
}
```

Facts are wrapped into events internally, so they go through `EventMiddleware` as well.
